### PR TITLE
update version condition for tgenv-install

### DIFF
--- a/libexec/tgenv-install
+++ b/libexec/tgenv-install
@@ -41,7 +41,7 @@ else
 fi
 
 [ -n "${version}" ] || error_and_die "Version is not specified"
-version="$(tgenv-list-remote | grep -e "${regex}" | head -n 1)"
+version="$(tgenv-list-remote-all | grep -e "${regex}" | head -n 1)"
 [ -n "${version}" ] || error_and_die "No versions matching '${1}' found in remote"
 
 dst_path="${TGENV_ROOT}/versions/${version}"


### PR DESCRIPTION
updating the version condition for tgenv-install.
The current condition causes tgenv-install to fail if version is older than the last 20.

```
tgenv: tgenv-install: [ERROR] No versions matching '0.18.x' found in remote
```

tgenv-install needs to check through all versions, not the last 20