### PR TITLE
feat: Overridable TGENV_VERSION

### DIFF
--- a/libexec/tgenv-version-name
+++ b/libexec/tgenv-version-name
@@ -8,8 +8,10 @@ source "${TGENV_ROOT}/libexec/helpers"
 [ -d "${TGENV_ROOT}/versions" ] \
   || error_and_die "No versions of terragrunt installed. Please install one with: tgenv install"
 
-TGENV_VERSION_FILE="$(tgenv-version-file)"
-TGENV_VERSION="$(cat "${TGENV_VERSION_FILE}" || true)"
+if test -z "${TGENV_VERSION:-}"; then
+  TGENV_VERSION_FILE="$(tgenv-version-file)"
+  TGENV_VERSION="$(cat "${TGENV_VERSION_FILE}" || true)"
+fi
 
 if [[ "${TGENV_VERSION}" =~ ^latest.*$ ]]; then
   [[ "${TGENV_VERSION}" =~ ^latest\:.*$ ]] && regex="${TGENV_VERSION##*\:}"


### PR DESCRIPTION
tgenv currently only relies in version files to dispatch the final terragrunt version.
This PR allows the version string that would otherwise come from version-file to come from an environment variable.

There's a corresponding tfenv pr at https://github.com/tfutils/tfenv/pull/150