### PR TITLE
Introduce flag 'TGENV_IGNORE_SHA' to disable signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ tgenv install
 
 If `shasum` is present in the path, tgenv will verify the download against Gruntwork's published sha256 hash.
 
-> Note: Signature verification does not work as it seems Gruntwork currently does no publish a signature.
+> Note: As of v0.18.1 Gruntwork provides signature verification. If you want to install older version, please set the envvar `TGENV_IGNORE_SHA` with any value. E.g. `export TGENV_IGNORE_SHA=1`
 
 #### .terragrunt-version
 If you use [.terragrunt-version](#terragrunt-version), `tgenv install` (no argument) will install the version written in it.

--- a/libexec/tgenv-install
+++ b/libexec/tgenv-install
@@ -81,8 +81,12 @@ trap "rm -rf ${download_tmp}" EXIT;
 
 info "Downloading release tarball from ${version_url}/${tarball_name}"
 curlw -L -# -f -o "${download_tmp}/${tarball_name}" "${version_url}/${tarball_name}" || error_and_die "Tarball download failed"
-info "Downloading SHA hash file from ${version_url}/${shasums_name}"
-curlw -L -s -f -o "${download_tmp}/${shasums_name}" "${version_url}/${shasums_name}" || error_and_die "SHA256 hashes download failed"
+if [ -z "${TGENV_IGNORE_SHA}" ]; then
+  info "Downloading SHA hash file from ${version_url}/${shasums_name}"
+  curlw -L -s -f -o "${download_tmp}/${shasums_name}" "${version_url}/${shasums_name}" || error_and_die "SHA256 hashes download failed"
+else
+  warn_and_continue "Flag to ignore SHA checksum is set"
+fi
 
 # Don't think gruntwork has signature file, so the following code is a mockup to simplify maintaining
 # parity with tfenv code base.


### PR DESCRIPTION
Prior to `v0.18.1` Terragrunt does not provide a SHA256SUM file (see Assets) [1].

This fix introduces a flag to skip signature verification. As result it's possible to install even older version. Otherwise this error occors: `tgenv: tgenv-install: [ERROR] SHA256 hashes download failed` 


[1] https://github.com/gruntwork-io/terragrunt/releases?after=v0.18.2